### PR TITLE
add custom Head hook to recipe editor template

### DIFF
--- a/src/class.ziprecipes.php
+++ b/src/class.ziprecipes.php
@@ -1048,6 +1048,8 @@ class ZipRecipes {
 		require_once(ABSPATH . 'wp-admin/includes/plugin.php');
 		$settings_page_url = admin_url( 'admin.php?page=' . 'zrdn-settings' );
 
+		$custom_head = apply_filters('ziprecipes_editor_customhead', '');
+
 		Util::print_view('create-update-recipe', array(
 			'pluginurl' => ZRDN_PLUGIN_URL,
 			'recipe_id' => $recipe_id,
@@ -1082,7 +1084,8 @@ class ZipRecipes {
 			'fat' => $fat,
 			'saturated_fat' => $saturated_fat,
 			'notes' => $notes,
-			'submit' => $submit
+			'submit' => $submit,
+			'custom_head' => $custom_head
  		));
 	}
 

--- a/src/styles/zlrecipe-dlog.css
+++ b/src/styles/zlrecipe-dlog.css
@@ -43,3 +43,5 @@ body#amd-zlrecipe-uploader { }
 #amd-zlrecipe-uploader #z_recipe_ingredients textarea.input-error { width: 585px !important; }
 #amd-zlrecipe-uploader p.error-message { color: red; font-weight: bold; }
 #amd-zlrecipe-uploader #recipe-title p.error-message { margin-left: 120px; }
+#amd-zlrecipe-uploader .recipe-image label { display: inline-block; vertical-align: top; }
+#amd-zlrecipe-uploader .recipe-image span { display: inline-block; }

--- a/src/views/create-update-recipe.twig
+++ b/src/views/create-update-recipe.twig
@@ -43,7 +43,7 @@
                 window.parent.zrdnAddImageHandler(zrdnRecipeImageSelected);
             });
 
-            var recipe_image_url = $('#recipe_image').val();
+            var recipe_image_url = $('#recipe_image > input').val();
             if (recipe_image_url)
             {
                 zrdnRecipeImageSelected({url: recipe_image_url});
@@ -121,6 +121,9 @@
     {% if post_info %}
 		<script>window.onload = amdZLRecipeSubmitForm;</script>
 	{% endif %}
+	{% if custom_head %}
+		{{ custom_head|e('js') }}
+	{% endif %}
 </head>
 <body id="amd-zlrecipe-uploader">
     {% autoescape false %}
@@ -138,20 +141,17 @@
 				<input type='hidden' name='recipe_post_id' value='{{ id }}' />
 				<input type='hidden' name='recipe_id' value='{{ recipe_id }}' />
 				<p id='recipe-title'><label>Recipe Title <span class='required'>*</span></label> <input type='text' name='recipe_title' value='{{ recipe_title }}' /></p>
-				<p id='recipe-image'>
-                    <div style="float:left; margin-left: 16px;">
-                        <label>Recipe Image</label>
-                        <input type='hidden' id="recipe_image" name='recipe_image' value='{{ recipe_image }}' />
-                    </div>
-                    <div id="upload-recipe-image-button-container" style="float: left; margin-left: 25px; padding-top: 5px;">
-                        <a id="upload-btn" href="#">Add Image</a>
-                    </div>
-                    <div id="recipe-image-preview-container" style="display: none; float: left; margin-left: 25px; text-align: center;">
-                        <img id="recipe-image-preview" src="" style="display: block" />
-                        <a href="javascript:zrdnResetImage()">Remove Image</a>
-                    </div>
-                </p>
-                <div style="clear: both"></div>
+				<p id='recipe-image' class='cls'>
+					<label>Recipe Image</label>
+					<input type='hidden' name='recipe_image' value='{{ recipe_image }}' />
+					<span id="upload-recipe-image-button-container" style="margin-left: 25px; padding-top: 5px;">
+						<a id="upload-btn" href="#">Add Image</a>
+					</span>
+					<span id="recipe-image-preview-container" style="display: none; margin-left: 25px; text-align: center;">
+						<img id="recipe-image-preview" src="" style="display: block" />
+						<a href="javascript:zrdnResetImage()">Remove Image</a>
+					</span>
+				</p>
 				<p id='z_recipe_ingredients' class='cls'>
                     <label>Ingredients
                         <span class='required'>*</span>


### PR DESCRIPTION
Hi Gezim,

I wasn't expecting a templating system for the editor page, so this is the best I could come up with without being specific about _my_ intended use of the hook.

Also I fixed the HTML section of the image: it was DIV inside P that is not allowed (no block element is allowed inside P) but funnily SPAN with "inline-block" is ok according to the browsers.

Also there was a bug of having two elements with ID "recipe_image" (P and INPUT), but luckily it didn't cause issue with the jQuery script.

What do you think?
