### PR TITLE
Fixed issue with recipe title not auto-generating

### DIFF
--- a/src/class.ziprecipes.php
+++ b/src/class.ziprecipes.php
@@ -163,7 +163,7 @@ class ZipRecipes {
 		if (is_admin()) {
 			?>
 			<script type="text/javascript">
-				var post_id = '<?php global $post; if ($post instanceof WP_Post) { echo $post->ID; } ?>';
+				var post_id = '<?php global $post; echo $post->ID; ?>';
 			</script>
 		<?php
 		}


### PR DESCRIPTION
This was due to fact that I was checking if $post was of WP_Post before
getting post id.
