### PR TITLE
Fixed: when packages are built, vendor only includes non-dev packages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,14 +34,16 @@ gulp.task("build-premium", function () {
   // used to change plugin name to Zip Recipes premium
   var mainPluginFileFilter = filter('zip-recipes.php', {restore: true});
 
-  return gulp.src(["src/**",
+  return gulp.src([
+    "src/**",
     "!src/README.md",
     "!src/composer.*",
     "!node_modules/**",
     "!src/vendor-dev/**",
     "!src/vendor-dev",
     "LICENSE",
-    "!src/plugins/**"])
+    "!src/plugins/**"
+  ])
     // rename premium read me
     .pipe(premiumFileFilter)
     .pipe(rename("README.md"))
@@ -83,7 +85,6 @@ gulp.task("build-free", function () {
     "LICENSE",
     "!src/plugins/**"
   ])
-    .pipe(debug())
     // move files to destination
     .pipe(gulp.dest(dest_free));
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "del": "^2.2.0",
     "gulp": "^3.9.0",
+    "gulp-debug":"2.1.2",
     "gulp-filter": "^3.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",


### PR DESCRIPTION
We don't want to ship dev composer packages.
