### PR TITLE
Move item rendering logic to template + added dummy tests

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -1,6 +1,7 @@
 {
     "require-dev": {
-        "phing/phing": "2.*"
+        "phing/phing": "2.*",
+        "phpunit/phpunit": "^5.3"
     },
     "require": {
         "twig/twig": "~1.0",

--- a/src/tests/bootstrap.php
+++ b/src/tests/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package zip-recipes
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually load the plugin being tested.
+ */
+function _manually_load_plugin() {
+	require dirname( dirname( __FILE__ ) ) . '/zip-recipes.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/src/tests/test-sample.php
+++ b/src/tests/test-sample.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Class SampleTest
+ *
+ * @package 
+ */
+
+/**
+ * Sample test case.
+ */
+class SampleTest extends WP_UnitTestCase {
+
+	/**
+	 * A single example test.
+	 */
+	function test_sample() {
+		// Replace this with some actual testing code.
+		$this->assertTrue( true );
+	}
+}
+

--- a/src/views/recipe.twig
+++ b/src/views/recipe.twig
@@ -185,43 +185,75 @@
       </div>
     {% endif %}
 
-    {# Add the ingredients #}
+    {# ********************* #}
+    {#       Ingredients     #}
+    {# ********************* #}
     {% if ingredient_label_hide != "Hide" %}
       <p id="zlrecipe-ingredients" class="h-4 strong">{{ ingredient_label }}</p>
     {% endif %}
 
-    {% if ingredient_list_type == 'ol' %}
-      <ol id="zlrecipe-ingredients-list">
-        {{ingredients|raw}}
-      </ol>
-    {% elseif ingredient_list_type == 'ul' or ingredient_list_type == 'l' %}
-      <ul id="zlrecipe-ingredients-list">
-        {{ingredients|raw}}
-      </ul>
-    {% elseif ingredient_list_type == 'p' or ingredient_list_type == 'div' %}
-      <span id="zlrecipe-ingredients-list">
-        {{ingredients|raw}}
-      </span>
-    {% endif %}
+    {% set ingredientsHtmlListElem = ingredient_list_type %}
+    {# one exception is when ingredient_list_type is 'l' #}
+    {% if ingredient_list_type == 'l' %}{% set ingredientsHtmlListElem = 'ul' %}{% endif %}
+    {% if ingredient_list_type == 'p' or ingredient_list_type =='div' %}{% set ingredientsHtmlListElem = 'span' %}{% endif %}
 
-    {# Add the instructions #}
+    {% set ingredientsHtmlListChildElem = 'li' %}
+    {% if ingredient_list_type == 'p' %}{% set ingredientsHtmlListChildElem = 'p' %}{% endif %}
+    {% if ingredient_list_type == 'div' %}{% set ingredientsHtmlListChildElem = 'div' %}{% endif %}
+    
+    <{{ ingredientsHtmlListElem }} id="zlrecipe-ingredients-list">
+      {% for ingredient in ingredients %}
+        {% if ingredient.type == 'image' %}
+          <img src="{{ ingredient.content }}" />
+        {% elseif ingredient.type == 'subtitle' %}
+          {# no itemprop for sub-titles (aka labels) #}
+          {# subtitles always use div #}
+          <div class="{% if ingredient_list_type == 'l' %}ingredient no-bullet-label{% else %}ingredient-label{% endif %}">
+            {{ ingredient.content|raw }}
+          </div>
+        {% else %}
+          <{{ ingredientsHtmlListChildElem }} class="ingredient {% if ingredient_list_type == 'l' %}no-bullet{% endif %}" itemprop="recipeIngredient">
+            {{ ingredient.content|raw }}
+          </{{ ingredientsHtmlListChildElem }}>
+        {% endif %}
+      {% endfor %}
+    </{{ ingredientsHtmlListElem }}>
+
+    {# ********************* #}
+    {#      Instructions     #}
+    {# ********************* #}
     {% if instruction_label_hide != 'Hide' %}
       <p id="zlrecipe-instructions" class="h-4 strong">{{ instruction_label }}</p>
     {% endif %}
 
-    {% if instruction_list_type == 'ul' or instruction_list_type == 'l' %}
-      <ul id="zlrecipe-instructions-list" class="instructions">
-        {{ instructions|raw }}
-      </ul>
-    {% elseif instruction_list_type == 'ol' %}
-      <ol id="zlrecipe-instructions-list" class="instructions">
-        {{ instructions|raw }}
-      </ol>
-    {% elseif instruction_list_type == 'p' or instruction_list_type == 'div' %}
-      <span id="zlrecipe-instructions-list" class="instructions">
-        {{ instructions|raw }}
-      </span>
-    {% endif %}
+    {% set instructionsHtmlListElem = instruction_list_type %}
+    {# one exception is when instruction_list_type is 'l' #}
+    {% if instruction_list_type == 'l' %}{% set instructionsHtmlListElem = 'ul' %}{% endif %}
+    {% if instruction_list_type == 'p' or instruction_list_type == 'div' %}{% set instructionsHtmlListElem = 'span' %}{% endif %}
+
+    {# child is always 'li' unless 'div' or 'p' #}
+    {% set instructionsHtmlChildElem = 'li' %}
+    {% if ingredient_list_type == 'p' %}{% set instructionsHtmlChildElem = 'p' %}{% endif %}
+    {% if ingredient_list_type == 'div' %}{% set instructionsHtmlChildElem = 'div' %}{% endif %}
+
+    <{{ instructionsHtmlListElem }} id="zlrecipe-instructions-list" class="instructions">
+      {% for instruction in instructions %}
+        {% if instruction.type == 'image' %}
+          <img src="{{ instruction.content }}" />
+        {% elseif instruction.type == 'subtitle' %}
+          {# no itemprop for sub-titles (aka labels) #}
+          {# subtitles always use div #}
+          <div class="{% if instruction_list_type == 'l' %}instruction no-bullet-label{% else %}instruction-label{% endif %}">
+            {{ instruction.content|raw }}
+          </div>
+        {% else %}
+          <{{ instructionsHtmlChildElem }} class="instruction {% if instruction_list_type == 'l' %}no-bullet{% endif %}" itemprop="recipeInstructions">
+          {{ instruction.content|raw }}
+          </{{ instructionsHtmlChildElem }}>
+        {% endif %}
+      {% endfor %}
+    </{{ instructionsHtmlListElem }}>
+
 
     {# !! add notes section #}
     {% if notes %}


### PR DESCRIPTION
Moved ingredient, instruction item rendering logic to template. Special syntax
is still converted to html outside the template (e.g. _bold_ to <b>bold</b>).

This was the last step to make all the recipe rendering happen on the template
in order to create mutliple templates, different style sheets, etc.

Important changes that may affect users:
`id` attribute is removed from ingredient, instruction items
`class="ingredient no-bullet-link"`, `class="instruction-link"` is removed from link in instructions, ingredients
`class="ingredient no-bullet-image"`, `class="instruction-image"` is removed from images in instructions, ingredients
