### PR TITLE
updated: add custom Head hook to recipe editor template

### DIFF
--- a/src/class.ziprecipes.php
+++ b/src/class.ziprecipes.php
@@ -908,6 +908,8 @@ class ZipRecipes {
 
 		require_once(ABSPATH . 'wp-admin/includes/plugin.php');
 		$settings_page_url = admin_url( 'admin.php?page=' . 'zrdn-settings' );
+		
+		$custom_head = apply_filters('ziprecipes_editor_customhead', '');
 
 		Util::print_view('create-update-recipe', array(
 			'pluginurl' => ZRDN_PLUGIN_URL,
@@ -943,7 +945,8 @@ class ZipRecipes {
 			'fat' => $fat,
 			'saturated_fat' => $saturated_fat,
 			'notes' => $notes,
-			'submit' => $submit
+			'submit' => $submit,
+			'custom_head' => $custom_head
  		));
 	}
 

--- a/src/styles/zlrecipe-dlog.css
+++ b/src/styles/zlrecipe-dlog.css
@@ -43,3 +43,5 @@ body#amd-zlrecipe-uploader { }
 #amd-zlrecipe-uploader #z_recipe_ingredients textarea.input-error { width: 585px !important; }
 #amd-zlrecipe-uploader p.error-message { color: red; font-weight: bold; }
 #amd-zlrecipe-uploader #recipe-title p.error-message { margin-left: 120px; }
+#amd-zlrecipe-uploader .recipe-image label { display: inline-block; vertical-align: top; }
+#amd-zlrecipe-uploader .recipe-image span { display: inline-block; }

--- a/src/views/create-update-recipe.twig
+++ b/src/views/create-update-recipe.twig
@@ -122,7 +122,7 @@
 		<script>window.onload = amdZLRecipeSubmitForm;</script>
 	{% endif %}
 	{% if custom_head %}
-		{{ custom_head|e('js') }}
+		{{ custom_head|raw }}
 	{% endif %}
 </head>
 <body id="amd-zlrecipe-uploader">

--- a/src/views/create-update-recipe.twig
+++ b/src/views/create-update-recipe.twig
@@ -43,7 +43,7 @@
                 window.parent.zrdnAddImageHandler(zrdnRecipeImageSelected);
             });
 
-            var recipe_image_url = $('#recipe_image').val();
+            var recipe_image_url = $('#recipe_image > input').val();
             if (recipe_image_url)
             {
                 zrdnRecipeImageSelected({url: recipe_image_url});
@@ -121,6 +121,9 @@
     {% if post_info %}
 		<script>window.onload = amdZLRecipeSubmitForm;</script>
 	{% endif %}
+	{% if custom_head %}
+		{{ custom_head|e('js') }}
+	{% endif %}
 </head>
 <body id="amd-zlrecipe-uploader">
     {% autoescape false %}
@@ -138,20 +141,17 @@
 				<input type='hidden' name='recipe_post_id' value='{{ id }}' />
 				<input type='hidden' name='recipe_id' value='{{ recipe_id }}' />
 				<p id='recipe-title'><label>Recipe Title <span class='required'>*</span></label> <input type='text' name='recipe_title' value='{{ recipe_title }}' /></p>
-				<p id='recipe-image'>
-                    <div style="float:left; margin-left: 16px;">
-                        <label>Recipe Image</label>
-                        <input type='hidden' id="recipe_image" name='recipe_image' value='{{ recipe_image }}' />
-                    </div>
-                    <div id="upload-recipe-image-button-container" style="float: left; margin-left: 25px; padding-top: 5px;">
-                        <a id="upload-btn" href="#">Add Image</a>
-                    </div>
-                    <div id="recipe-image-preview-container" style="display: none; float: left; margin-left: 25px; text-align: center;">
-                        <img id="recipe-image-preview" src="" style="display: block" />
-                        <a href="javascript:zrdnResetImage()">Remove Image</a>
-                    </div>
-                </p>
-                <div style="clear: both"></div>
+				<p id='recipe-image' class='cls'>
+					<label>Recipe Image</label>
+					<input type='hidden' name='recipe_image' value='{{ recipe_image }}' />
+					<span id="upload-recipe-image-button-container" style="margin-left: 25px; padding-top: 5px;">
+						<a id="upload-btn" href="#">Add Image</a>
+					</span>
+					<span id="recipe-image-preview-container" style="display: none; margin-left: 25px; text-align: center;">
+						<img id="recipe-image-preview" src="" style="display: block" />
+						<a href="javascript:zrdnResetImage()">Remove Image</a>
+					</span>
+				</p>
 				<p id='z_recipe_ingredients' class='cls'>
                     <label>Ingredients
                         <span class='required'>*</span>


### PR DESCRIPTION
If I haven't mentioned earlier: the HTML fix is because you can't have a DIV inside of a P.
Of course browsers handle it in some way even if it's broken, but it's cleaner to have it properly.
