### PR TITLE
Load global translations before plugin translation

### DIFF
--- a/src/class.ziprecipes.php
+++ b/src/class.ziprecipes.php
@@ -685,8 +685,12 @@ class ZipRecipes {
 		/**
 		 * Loading translations
 		 */
-		$langDir = plugin_basename( dirname( __FILE__ ) ) . '/languages/';
-		load_plugin_textdomain('zip-recipes', false, $langDir);
+		$pluginLangDir = plugin_basename( dirname( __FILE__ ) ) . '/languages/';
+		$globalLangDir = WP_LANG_DIR; // full path
+		if (is_readable($globalLangDir)) {
+			load_plugin_textdomain('zip-recipes', false, $globalLangDir);
+		}
+		load_plugin_textdomain('zip-recipes', false, $pluginLangDir);
 	}
 
 	// Content for the popup iframe when creating or editing a recipe


### PR DESCRIPTION
This allows user to save zip-recipes-<code>.mo in wp-content/languages
and have that take precedence over zip-recipes/languages/zip-recipes-<code>.mo files.
