### PR TITLE
Ignore rule for hidden plugin's classes.

### DIFF
--- a/src/class.ziprecipes.php
+++ b/src/class.ziprecipes.php
@@ -33,7 +33,7 @@ class ZipRecipes {
 			while (false !== ($fileOrFolder = readdir($pluginsDirHandle)))
 			{
 				$notDir = ! is_dir($fileOrFolder);
-				$invalidDir = $fileOrFolder === "." || $fileOrFolder === "..";
+                $invalidDir = $fileOrFolder === "." || $fileOrFolder === ".." || $fileOrFolder === '_internal';
 				// we don't care about files inside `plugins` dir
 				if ($notDir || $invalidDir)
 				{


### PR DESCRIPTION
Small fix we disccussed earlier. One to ignore _internal dir in src/plugins.
