### PR TITLE
Hooks and setup for Authors feature

### DIFF
--- a/src/styles/zlrecipe-dlog.css
+++ b/src/styles/zlrecipe-dlog.css
@@ -23,7 +23,7 @@ body#amd-zlrecipe-uploader { }
 #amd-zlrecipe-uploader p { margin: 16px; display: block; width: 590px; }
 #amd-zlrecipe-uploader label { font-weight: bold; font-size: 116%; line-height: 25px; }
 #amd-zlrecipe-uploader span.required { color: red; }
-#amd-zlrecipe-uploader input[type="text"], #amd-zlrecipe-uploader textarea { width: 460px; border: 1px solid #DFDFDF; float: right; line-height: 15px; margin: 1px; padding: 3px; -moz-border-radius: 4px; -khtml-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px; }
+#amd-zlrecipe-uploader input[type="text"], #amd-zlrecipe-uploader select, #amd-zlrecipe-uploader textarea { width: 520px; border: 1px solid #DFDFDF; float: right; line-height: 15px; margin: 1px; padding: 3px; -moz-border-radius: 4px; -khtml-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px; }
 #amd-zlrecipe-uploader textarea { height: 100px; }
 #amd-zlrecipe-uploader select { padding: 3px; }
 #amd-zlrecipe-uploader input[type='text']:focus, #amd-zlrecipe-uploader input.text:focus, #amd-zlrecipe-uploader input[type='password']:focus, #amd-zlrecipe-uploader textarea:focus { background-color: #eee; border-color: #ccc; color:#383f41; -webkit-box-shadow:0 0 5px rgba(160,160,112,0.6); }

--- a/src/views/create-update-recipe.twig
+++ b/src/views/create-update-recipe.twig
@@ -137,10 +137,10 @@
 			<div id='amd-zlrecipe-form-items'>
 				<input type='hidden' name='recipe_post_id' value='{{ id }}' />
 				<input type='hidden' name='recipe_id' value='{{ recipe_id }}' />
-				<p id='recipe-title'><label>Recipe Title <span class='required'>*</span></label> <input type='text' name='recipe_title' value='{{ recipe_title }}' /></p>
+				<p id='recipe-title'><label for='recipe_title'>Title <span class='required'>*</span></label> <input type='text' id='recipe_title' name='recipe_title' value='{{ recipe_title }}' /></p>
 				<p id='recipe-image'>
                     <div style="float:left; margin-left: 16px;">
-                        <label>Recipe Image</label>
+                        <label>Image</label>
                         <input type='hidden' id="recipe_image" name='recipe_image' value='{{ recipe_image }}' />
                     </div>
                     <div id="upload-recipe-image-button-container" style="float: left; margin-left: 25px; padding-top: 5px;">
@@ -150,8 +150,9 @@
                         <img id="recipe-image-preview" src="" style="display: block" />
                         <a href="javascript:zrdnResetImage()">Remove Image</a>
                     </div>
-                </p>
-                <div style="clear: both"></div>
+        </p>
+        <div style="clear: both"></div>
+        {{ author_section|raw }}
 				<p id='z_recipe_ingredients' class='cls'>
                     <label>Ingredients
                         <span class='required'>*</span>

--- a/src/views/recipe.twig
+++ b/src/views/recipe.twig
@@ -58,6 +58,8 @@
           </p>
         {% endif %}
 
+        {{ author_section|raw }}
+
         {# !! close the first container div and open the second #}
       </div>
 

--- a/src/views/settings.twig
+++ b/src/views/settings.twig
@@ -32,6 +32,7 @@
           <th scope="row">Printed Output: Copyright Statement</th>
           <td><input type="text" name="printed-copyright-statement" value="{{ printed_copyright_statement }}" class="regular-text" /></td>
         </tr>
+        {{ author_section|raw }}
       </table>
 
       <hr />
@@ -139,6 +140,7 @@
       <p><input type="submit" name="submit" id="submit" class="button-primary" value="Save Changes"></p>
     {% else %}
       <script type="text/javascript">
+        // REGISTRATION FORM SCRIPT
         var $form = jQuery("#zlrecipe_settings_form");
 
         $form.on("submit", function ()

--- a/src/zip-recipes.php
+++ b/src/zip-recipes.php
@@ -51,13 +51,13 @@ require_once(ZRDN_PLUGIN_DIRECTORY . 'class.ziprecipes.php');
 
 Util::log("Setting up init hooks.");
 
-// Add initial hooks
-add_action( 'init', __NAMESPACE__ . '\ZipRecipes::init' );
 add_action('upgrader_process_complete', __NAMESPACE__ . '\ZipRecipes::plugin_updated', 10, 2);
 
 // Leaving register_activation_hook here because it's using __FILE__ and it needs to use the main plugin file, which is
 //  this file.
 register_activation_hook(__FILE__, __NAMESPACE__ . '\ZipRecipes::init');
+
+ZipRecipes::init();
 
 // Setup query catch for recipe insertion popup.
 if (strpos($_SERVER['REQUEST_URI'], 'media-upload.php') && strpos($_SERVER['REQUEST_URI'], '&type=z_recipe') && !strpos($_SERVER['REQUEST_URI'], '&wrt='))


### PR DESCRIPTION
Added all types of hooks to save, load recipe with author info, save
author info into settings, etc.

One major kind of change is the way database upgrade is done. Since
dbDelta doesn't actually delete columns, I removed the guard to see
which table version is installed and only do changes if there's a version
change. The reason for this is because plugins, such as Authors plugin
needs to be able to modify database schema and tracking the version
that the plugin wants + the version that Zip Recipes core wants is tricky
and not worth doing.

Also, removed 'init' hook since it was being called at wrong time for
Author plugin to work. It's not needed anyway, since the `upgraer_process_complete`
hook works.
