### PR TITLE
Pass blank string to zrdn__automatic_nutrition_get_label

### DIFF
--- a/src/class.ziprecipes.php
+++ b/src/class.ziprecipes.php
@@ -318,7 +318,9 @@ class ZipRecipes {
             'author_section' => apply_filters('zrdn__authors_render_author_for_recipe', '', $recipe),
             // author is used in other themes
             'author' => apply_filters('zrdn__authors_get_author_for_recipe', '', $recipe),
-            'nutrition_label' => apply_filters('zrdn__automatic_nutrition_get_label', $recipe),
+            // The second argument to apply_filters is what is returned if no one implements this hook.
+            // For `nutrition_label`, we want an empty string, not $recipe object.
+            'nutrition_label' => apply_filters('zrdn__automatic_nutrition_get_label', '', $recipe),
             'amp_on' => $amp_on
         );
         $custom_template = apply_filters('zrdn__custom_templates_get_formatted_recipe', false, $viewParams);


### PR DESCRIPTION
This fixes issue where rendering of a post fails when Automatic Nutrition
is disabled. For example, non-English websites.